### PR TITLE
fix bug in upper bounce exclusivity

### DIFF
--- a/consistent_hash/consistent_hash.py
+++ b/consistent_hash/consistent_hash.py
@@ -125,7 +125,7 @@ class ConsistentHash(object):
 
         for j in xrange(0, int(factor)):
             b_key = self._hash_digest('%s-%s' % (node, j))
-            for i in xrange(0, 3):
+            for i in xrange(4):
                 yield self._hash_val(b_key, lambda x: x + i * 4)
 
     def get_node(self, string_key):


### PR DESCRIPTION
 * xrange(0, 3) produces 3 iterations instead of 4 because the stop
   value is exclusive.
 * make slightly more pythonic by just doing xrange(4) since start
   defaults to 0

Was testing this against other ketama implementations, notably http://wiki.nginx.org/HttpUpstreamKetamaCHashModule and noticed different continuum results. Looking at the original ketama implementation, https://github.com/RJ/ketama/blob/master/libketama/ketama.c#L448-L454 I noticed that it was creating 4 4-byte ints.